### PR TITLE
Fix alwaysWrite feature

### DIFF
--- a/src/main/java/mchorse/mclib/utils/ValueSerializer.java
+++ b/src/main/java/mchorse/mclib/utils/ValueSerializer.java
@@ -259,15 +259,15 @@ public class ValueSerializer implements IByteBufSerializable, INBTSerializable
     {
         for (Map.Entry<String, String> entry : this.nbtMap.entrySet())
         {
-            GenericBaseValue value = this.pool.get(entry.getValue());
-            String uuid = entry.getKey();
+            String uuid = entry.getValue();
+            GenericBaseValue value = this.pool.get(uuid);
 
             if (!this.nbtAlwaysWrite.contains(uuid) && value instanceof GenericValue && !((GenericValue) value).hasChanged())
             {
                 continue;
             }
 
-            tag.setTag(uuid, value.valueToNBT());
+            tag.setTag(entry.getKey(), value.valueToNBT());
         }
 
         return tag;
@@ -283,15 +283,15 @@ public class ValueSerializer implements IByteBufSerializable, INBTSerializable
 
         for (Map.Entry<String, String> entry : this.jsonMap.entrySet())
         {
-            GenericBaseValue value = this.pool.get(entry.getValue());
-            String uuid = entry.getKey();
+            String uuid = entry.getValue();
+            GenericBaseValue value = this.pool.get(uuid);
 
             if (!this.jsonAlwaysWrite.contains(uuid) && value instanceof GenericValue && !((GenericValue) value).hasChanged())
             {
                 continue;
             }
 
-            jsonRoot.add(uuid, value.valueToJSON());
+            jsonRoot.add(entry.getKey(), value.valueToJSON());
         }
 
         return jsonRoot;


### PR DESCRIPTION
I wanted to use the alwaysWrite functionality to build a JSON object for requests. However, I found that it never works.

https://github.com/mchorse/mclib/blob/ded2eff622628c1bc4e68fc73a88436a73e1a7df/src/main/java/mchorse/mclib/utils/ValueSerializer.java#L42-L45
https://github.com/mchorse/mclib/blob/ded2eff622628c1bc4e68fc73a88436a73e1a7df/src/main/java/mchorse/mclib/utils/ValueSerializer.java#L47-L49
Judging from these comments, `nbtAlwaysWrite` contains UUIDs, and in `nbtMap` the UUID is a value, not a key.
However, https://github.com/mchorse/mclib/blob/ded2eff622628c1bc4e68fc73a88436a73e1a7df/src/main/java/mchorse/mclib/utils/ValueSerializer.java#L258-L272
here the UUID is taken from the key. During debugging, you can see that it is not a UUID, but a name. In addition, on the line above the value it takes an element from the pool, where the key is the UUID, so everything works correctly there.
But when it comes to the `!this.nbtAlwaysWrite.contains(uuid)` check, the name is checked instead of the UUID, and this check is always true.

All of the above is also true for JSON.